### PR TITLE
Feat/#20 - PrivateMessage 도메인 테이블 구조 설계 및 유스 케이스 작성 및 구현 ( CQRS 첫 도입)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,39 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    querydslVersion = '6.10.1'
+}
+
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // QueryDSL
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${querydslVersion}:jpa"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
+
+    // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Testcontainers
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/bak/global/common/persistence/ReadOnlyRepository.java
+++ b/src/main/java/com/example/bak/global/common/persistence/ReadOnlyRepository.java
@@ -1,0 +1,16 @@
+package com.example.bak.global.common.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
+
+@NoRepositoryBean
+public interface ReadOnlyRepository<T, ID> extends Repository<T, ID> {
+
+    Optional<T> findById(ID id);
+    
+    List<T> findAll();
+
+    boolean existsById(ID id);
+}

--- a/src/main/java/com/example/bak/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/bak/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.bak.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/example/bak/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/bak/global/exception/ErrorCode.java
@@ -24,11 +24,16 @@ public enum ErrorCode {
     // Feed
     FEED_NOT_FOUND("FE001", HttpStatus.NOT_FOUND, "피드 리소스를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND("CM001", HttpStatus.NOT_FOUND, "댓글 리소스를 찾을 수 없습니다."),
-    UNAUTHORIZED_ACTION("CM002", HttpStatus.FORBIDDEN, "권한이 없는 작업입니다."),
 
     // Community
-    COMMUNITY_NOT_FOUND("CO001", HttpStatus.NOT_FOUND, "커뮤니티 리소스를 찾을 수 없습니다.");
+    COMMUNITY_NOT_FOUND("CO001", HttpStatus.NOT_FOUND, "커뮤니티 리소스를 찾을 수 없습니다."),
 
+    // Private Message
+    MESSAGE_NOT_FOUND("PM001", HttpStatus.NOT_FOUND, "쪽지 리소스를 찾을 수 없습니다."),
+
+    // Global
+    UNAUTHORIZED_ACTION("CM002", HttpStatus.FORBIDDEN, "권한이 없는 작업입니다.");
+    
     private final String code;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/bak/privatemessage/application/command/MessageCommandService.java
+++ b/src/main/java/com/example/bak/privatemessage/application/command/MessageCommandService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MessageCommandService {
 
     private final MessageCommandPort messageCommandPort;
-    
+
     public void sendMessage(Long senderId, Long receiverId, String content) {
         Message message = Message.create(senderId, receiverId, content);
         messageCommandPort.save(message);
@@ -26,7 +26,6 @@ public class MessageCommandService {
         messageCommandPort.markAsRead(participants);
     }
 
-    @Transactional
     public void deleteMessage(Long userId, Long messageId) {
         Message message = messageCommandPort.findById(messageId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MESSAGE_NOT_FOUND));

--- a/src/main/java/com/example/bak/privatemessage/application/command/MessageCommandService.java
+++ b/src/main/java/com/example/bak/privatemessage/application/command/MessageCommandService.java
@@ -1,0 +1,53 @@
+package com.example.bak.privatemessage.application.command;
+
+import com.example.bak.global.exception.BusinessException;
+import com.example.bak.global.exception.ErrorCode;
+import com.example.bak.privatemessage.application.command.port.MessageCommandPort;
+import com.example.bak.privatemessage.domain.Message;
+import com.example.bak.privatemessage.domain.MessageParticipants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class MessageCommandService {
+
+    private final MessageCommandPort messageCommandPort;
+    
+    public void sendMessage(Long senderId, Long receiverId, String content) {
+        Message message = Message.create(senderId, receiverId, content);
+        messageCommandPort.save(message);
+    }
+
+    public void markAsRead(Long senderId, Long receiverId) {
+        MessageParticipants participants = MessageParticipants.of(senderId, receiverId);
+        messageCommandPort.markAsRead(participants);
+    }
+
+    @Transactional
+    public void deleteMessage(Long userId, Long messageId) {
+        Message message = messageCommandPort.findById(messageId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MESSAGE_NOT_FOUND));
+
+        deleteByRole(message, userId);
+    }
+
+    private void deleteByRole(Message message, Long userId) {
+        Long senderId = message.getMessageParticipants().getSenderId();
+        Long receiverId = message.getMessageParticipants().getReceiverId();
+
+        if (userId.equals(senderId)) {
+            message.getMessageState().deleteBySender();
+            return;
+        }
+
+        if (userId.equals(receiverId)) {
+            message.getMessageState().deleteByReceiver();
+            return;
+        }
+
+        throw new BusinessException(ErrorCode.UNAUTHORIZED_ACTION);
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/application/command/port/MessageCommandPort.java
+++ b/src/main/java/com/example/bak/privatemessage/application/command/port/MessageCommandPort.java
@@ -1,0 +1,14 @@
+package com.example.bak.privatemessage.application.command.port;
+
+import com.example.bak.privatemessage.domain.Message;
+import com.example.bak.privatemessage.domain.MessageParticipants;
+import java.util.Optional;
+
+public interface MessageCommandPort {
+
+    Message save(Message message);
+
+    void markAsRead(MessageParticipants participants);
+
+    Optional<Message> findById(Long messageId);
+}

--- a/src/main/java/com/example/bak/privatemessage/application/query/MessageQueryService.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/MessageQueryService.java
@@ -1,0 +1,23 @@
+package com.example.bak.privatemessage.application.query;
+
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import com.example.bak.privatemessage.application.query.port.MessageQueryPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageQueryService {
+
+    private final MessageQueryPort messageQueryPort;
+
+    public List<MessagePartnerResult> getPartnersByUserId(Long userId) {
+        return messageQueryPort.findPartnersByUserId(userId);
+    }
+
+    public List<MessageItemResult> getMessagesBetweenUsers(Long fromUserId, Long toUserId) {
+        return messageQueryPort.findMessagesBetweenUsers(fromUserId, toUserId);
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/application/query/MessageQueryService.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/MessageQueryService.java
@@ -1,7 +1,7 @@
 package com.example.bak.privatemessage.application.query;
 
+import com.example.bak.privatemessage.application.query.dto.MessageCorrespondentResult;
 import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
-import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
 import com.example.bak.privatemessage.application.query.port.MessageQueryPort;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +13,8 @@ public class MessageQueryService {
 
     private final MessageQueryPort messageQueryPort;
 
-    public List<MessagePartnerResult> getPartnersByUserId(Long userId) {
-        return messageQueryPort.findPartnersByUserId(userId);
+    public List<MessageCorrespondentResult> getMessageCorrespondentsByUserId(Long userId) {
+        return messageQueryPort.findCorrespondentsByUserId(userId);
     }
 
     public List<MessageItemResult> getMessagesBetweenUsers(Long fromUserId, Long toUserId) {

--- a/src/main/java/com/example/bak/privatemessage/application/query/dto/MessageCorrespondentResult.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/dto/MessageCorrespondentResult.java
@@ -1,7 +1,7 @@
 package com.example.bak.privatemessage.application.query.dto;
 
-public record MessagePartnerResult(
-        Long partnerId,
+public record MessageCorrespondentResult(
+        Long correspondentId,
         String nickname,
         Boolean hasUnread
 ) {

--- a/src/main/java/com/example/bak/privatemessage/application/query/dto/MessageItemResult.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/dto/MessageItemResult.java
@@ -1,0 +1,14 @@
+package com.example.bak.privatemessage.application.query.dto;
+
+import java.time.LocalDateTime;
+
+public record MessageItemResult(
+        Long id,
+        Long senderId,
+        Long receiverId,
+        String content,
+        //created_at 추가
+        LocalDateTime readAt
+) {
+
+}

--- a/src/main/java/com/example/bak/privatemessage/application/query/dto/MessagePartnerResult.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/dto/MessagePartnerResult.java
@@ -1,0 +1,9 @@
+package com.example.bak.privatemessage.application.query.dto;
+
+public record MessagePartnerResult(
+        Long partnerId,
+        String nickname,
+        Boolean hasUnread
+) {
+
+}

--- a/src/main/java/com/example/bak/privatemessage/application/query/port/MessageQueryPort.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/port/MessageQueryPort.java
@@ -1,0 +1,12 @@
+package com.example.bak.privatemessage.application.query.port;
+
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import java.util.List;
+
+public interface MessageQueryPort {
+
+    List<MessagePartnerResult> findPartnersByUserId(Long userId);
+
+    List<MessageItemResult> findMessagesBetweenUsers(Long fromUserId, Long toUserId);
+}

--- a/src/main/java/com/example/bak/privatemessage/application/query/port/MessageQueryPort.java
+++ b/src/main/java/com/example/bak/privatemessage/application/query/port/MessageQueryPort.java
@@ -1,12 +1,12 @@
 package com.example.bak.privatemessage.application.query.port;
 
+import com.example.bak.privatemessage.application.query.dto.MessageCorrespondentResult;
 import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
-import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
 import java.util.List;
 
 public interface MessageQueryPort {
 
-    List<MessagePartnerResult> findPartnersByUserId(Long userId);
+    List<MessageCorrespondentResult> findCorrespondentsByUserId(Long userId);
 
     List<MessageItemResult> findMessagesBetweenUsers(Long fromUserId, Long toUserId);
 }

--- a/src/main/java/com/example/bak/privatemessage/domain/Message.java
+++ b/src/main/java/com/example/bak/privatemessage/domain/Message.java
@@ -1,0 +1,59 @@
+package com.example.bak.privatemessage.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PostLoad;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "private_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private MessageParticipants messageParticipants;
+
+    @Embedded
+    private MessageState messageState;
+
+    @Column(nullable = false)
+    private String content;
+
+    private Message(
+            MessageParticipants messageParticipants,
+            String content
+    ) {
+        this.messageParticipants = messageParticipants;
+        this.content = content;
+    }
+
+    public static Message create(
+            Long senderId,
+            Long receiverId,
+            String content
+    ) {
+        MessageParticipants participants = MessageParticipants.of(senderId, receiverId);
+        Message message = new Message(participants, content);
+        message.messageState = MessageState.init();
+        return message;
+    }
+
+    @PostLoad
+    private void postLoad() {
+        if (this.messageState == null) {
+            this.messageState = MessageState.init();
+        }
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/domain/MessageParticipants.java
+++ b/src/main/java/com/example/bak/privatemessage/domain/MessageParticipants.java
@@ -1,0 +1,25 @@
+package com.example.bak.privatemessage.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageParticipants {
+
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    @Column(name = "receiver_id", nullable = false)
+    private Long receiverId;
+
+    public static MessageParticipants of(Long senderId, Long receiverId) {
+        return new MessageParticipants(senderId, receiverId);
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/domain/MessageParticipants.java
+++ b/src/main/java/com/example/bak/privatemessage/domain/MessageParticipants.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MessageParticipants {
 

--- a/src/main/java/com/example/bak/privatemessage/domain/MessageState.java
+++ b/src/main/java/com/example/bak/privatemessage/domain/MessageState.java
@@ -1,0 +1,40 @@
+package com.example.bak.privatemessage.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class MessageState {
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "deleted_at_by_sender")
+    private LocalDateTime deletedAtBySender;
+
+    @Column(name = "deleted_at_by_receiver")
+    private LocalDateTime deletedAtByReceiver;
+
+    public static MessageState init() {
+        return new MessageState();
+    }
+
+    public void markAsRead() {
+        if (this.readAt == null) {
+            this.readAt = LocalDateTime.now();
+        }
+    }
+
+    public void deleteBySender() {
+        this.deletedAtBySender = LocalDateTime.now();
+    }
+
+    public void deleteByReceiver() {
+        this.deletedAtByReceiver = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/command/MessageCommandRepositoryAdapter.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/command/MessageCommandRepositoryAdapter.java
@@ -1,0 +1,33 @@
+package com.example.bak.privatemessage.infra.command;
+
+import com.example.bak.privatemessage.application.command.port.MessageCommandPort;
+import com.example.bak.privatemessage.domain.Message;
+import com.example.bak.privatemessage.domain.MessageParticipants;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageCommandRepositoryAdapter implements MessageCommandPort {
+
+    private final MessageJpaRepository messageJpaRepository;
+
+    @Override
+    public Message save(Message message) {
+        return messageJpaRepository.save(message);
+    }
+
+    @Override
+    public void markAsRead(MessageParticipants participants) {
+        messageJpaRepository.markAsReadByParticipants(
+                participants.getSenderId(),
+                participants.getReceiverId()
+        );
+    }
+
+    @Override
+    public Optional<Message> findById(Long messageId) {
+        return messageJpaRepository.findById(messageId);
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/command/MessageJpaRepository.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/command/MessageJpaRepository.java
@@ -1,0 +1,23 @@
+package com.example.bak.privatemessage.infra.command;
+
+import com.example.bak.privatemessage.domain.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MessageJpaRepository extends JpaRepository<Message, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+                update private_messages m
+                set m.messageState.readAt = CURRENT_TIMESTAMP
+                where m.messageParticipants.receiverId = :receiverId
+                  and m.messageParticipants.senderId = :senderId
+                  and m.messageState.readAt is null
+            """)
+    int markAsReadByParticipants(
+            @Param("senderId") Long senderId,
+            @Param("receiverId") Long receiverId
+    );
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/query/MessageQueryAdapter.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/MessageQueryAdapter.java
@@ -1,7 +1,7 @@
 package com.example.bak.privatemessage.infra.query;
 
+import com.example.bak.privatemessage.application.query.dto.MessageCorrespondentResult;
 import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
-import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
 import com.example.bak.privatemessage.application.query.port.MessageQueryPort;
 import com.example.bak.privatemessage.infra.query.jdbc.MessageJdbcRepository;
 import java.util.List;
@@ -15,8 +15,8 @@ public class MessageQueryAdapter implements MessageQueryPort {
     private final MessageJdbcRepository messageJdbcRepository;
 
     @Override
-    public List<MessagePartnerResult> findPartnersByUserId(Long userId) {
-        return messageJdbcRepository.findPartnersByUserId(userId);
+    public List<MessageCorrespondentResult> findCorrespondentsByUserId(Long userId) {
+        return messageJdbcRepository.findCorrespondentsByUserId(userId);
     }
 
     @Override

--- a/src/main/java/com/example/bak/privatemessage/infra/query/MessageQueryAdapter.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/MessageQueryAdapter.java
@@ -1,0 +1,26 @@
+package com.example.bak.privatemessage.infra.query;
+
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import com.example.bak.privatemessage.application.query.port.MessageQueryPort;
+import com.example.bak.privatemessage.infra.query.jdbc.MessageJdbcRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MessageQueryAdapter implements MessageQueryPort {
+
+    private final MessageJdbcRepository messageJdbcRepository;
+
+    @Override
+    public List<MessagePartnerResult> findPartnersByUserId(Long userId) {
+        return messageJdbcRepository.findPartnersByUserId(userId);
+    }
+
+    @Override
+    public List<MessageItemResult> findMessagesBetweenUsers(Long fromUserId, Long toUserId) {
+        return messageJdbcRepository.findMessagesBetweenUsers(fromUserId, toUserId);
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/MessageJdbcRepository.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/MessageJdbcRepository.java
@@ -1,12 +1,12 @@
 package com.example.bak.privatemessage.infra.query.jdbc;
 
+import com.example.bak.privatemessage.application.query.dto.MessageCorrespondentResult;
 import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
-import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
 import java.util.List;
 
 public interface MessageJdbcRepository {
 
-    List<MessagePartnerResult> findPartnersByUserId(Long userId);
+    List<MessageCorrespondentResult> findCorrespondentsByUserId(Long userId);
 
     List<MessageItemResult> findMessagesBetweenUsers(Long fromUserId, Long toUserId);
 }

--- a/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/MessageJdbcRepository.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/MessageJdbcRepository.java
@@ -1,0 +1,12 @@
+package com.example.bak.privatemessage.infra.query.jdbc;
+
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import java.util.List;
+
+public interface MessageJdbcRepository {
+
+    List<MessagePartnerResult> findPartnersByUserId(Long userId);
+
+    List<MessageItemResult> findMessagesBetweenUsers(Long fromUserId, Long toUserId);
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/MessageJdbcRepositoryImpl.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/MessageJdbcRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.example.bak.privatemessage.infra.query.jdbc;
+
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageJdbcRepositoryImpl implements MessageJdbcRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    @Override
+    public List<MessagePartnerResult> findPartnersByUserId(Long userId) {
+
+        String sql = """
+                SELECT
+                    t.partner_id AS partner_id,
+                    p.nickname AS nickname,
+                    CASE
+                        WHEN u.unread_count > 0 THEN TRUE
+                        ELSE FALSE
+                    END AS has_unread
+                FROM (
+                    SELECT pm.partner_id
+                    FROM (
+                        SELECT receiver_id AS partner_id
+                        FROM private_messages
+                        WHERE sender_id = :userId
+                          AND deleted_at_by_sender IS NULL
+                        UNION ALL
+                        SELECT sender_id AS partner_id
+                        FROM private_messages
+                        WHERE receiver_id = :userId
+                          AND deleted_at_by_receiver IS NULL
+                    ) pm
+                    GROUP BY pm.partner_id
+                ) t
+                LEFT JOIN (
+                    SELECT sender_id AS partner_id, COUNT(*) AS unread_count
+                    FROM private_messages
+                    WHERE receiver_id = :userId
+                      AND read_at IS NULL
+                      AND deleted_at_by_receiver IS NULL
+                    GROUP BY sender_id
+                ) u ON u.partner_id = t.partner_id
+                JOIN profiles p ON p.user_id = t.partner_id
+                
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("userId", userId);
+
+        return jdbc.query(sql, params, (rs, rowNum) ->
+                new MessagePartnerResult(
+                        rs.getLong("partner_id"),
+                        rs.getString("nickname"),
+                        rs.getInt("has_unread") == 1
+                )
+        );
+    }
+
+    @Override
+    public List<MessageItemResult> findMessagesBetweenUsers(Long fromUserId, Long toUserId) {
+
+        String sql = """
+                SELECT 
+                    id,
+                    sender_id,
+                    receiver_id,
+                    content,
+                    read_at
+                FROM private_messages
+                WHERE (sender_id = :fromUserId AND receiver_id = :toUserId)
+                   OR (sender_id = :toUserId AND receiver_id = :fromUserId)
+                order by id desc
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("fromUserId", fromUserId)
+                .addValue("toUserId", toUserId);
+
+        return jdbc.query(sql, params, (rs, rowNum) ->
+                new MessageItemResult(
+                        rs.getLong("id"),
+                        rs.getLong("sender_id"),
+                        rs.getLong("receiver_id"),
+                        rs.getString("content"),
+                        rs.getTimestamp("read_at") == null ? null
+                                : rs.getTimestamp("read_at").toLocalDateTime()
+                )
+        );
+    }
+
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/mapper/MessageCorrespondentRowMapper.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/mapper/MessageCorrespondentRowMapper.java
@@ -1,0 +1,18 @@
+package com.example.bak.privatemessage.infra.query.jdbc.mapper;
+
+import com.example.bak.privatemessage.application.query.dto.MessageCorrespondentResult;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+public class MessageCorrespondentRowMapper implements RowMapper<MessageCorrespondentResult> {
+
+    @Override
+    public MessageCorrespondentResult mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new MessageCorrespondentResult(
+                rs.getLong("partner_id"),
+                rs.getString("nickname"),
+                rs.getBoolean("has_unread")
+        );
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/mapper/MessageItemRowMapper.java
+++ b/src/main/java/com/example/bak/privatemessage/infra/query/jdbc/mapper/MessageItemRowMapper.java
@@ -1,0 +1,22 @@
+package com.example.bak.privatemessage.infra.query.jdbc.mapper;
+
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+public class MessageItemRowMapper implements RowMapper<MessageItemResult> {
+
+    @Override
+    public MessageItemResult mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new MessageItemResult(
+                rs.getLong("id"),
+                rs.getLong("sender_id"),
+                rs.getLong("receiver_id"),
+                rs.getString("content"),
+                rs.getTimestamp("read_at") == null
+                        ? null
+                        : rs.getTimestamp("read_at").toLocalDateTime()
+        );
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/presentation/MessageController.java
+++ b/src/main/java/com/example/bak/privatemessage/presentation/MessageController.java
@@ -4,9 +4,6 @@ import com.example.bak.global.common.response.ApiResponse;
 import com.example.bak.global.common.response.ApiResponseFactory;
 import com.example.bak.privatemessage.application.command.MessageCommandService;
 import com.example.bak.privatemessage.application.query.MessageQueryService;
-import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
-import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,7 +41,7 @@ public class MessageController {
 
     @GetMapping("/participants")
     public ResponseEntity<ApiResponse> getParticipants(@RequestParam Long userId) {
-        List<MessagePartnerResult> result = queryService.getPartnersByUserId(userId);
+        var result = queryService.getMessageCorrespondentsByUserId(userId);
         return ResponseEntity.ok(ApiResponseFactory.success("쪽지 대화 상대 목록을 조회하였습니다.", result));
     }
 
@@ -53,10 +50,7 @@ public class MessageController {
             @RequestParam Long userId,
             @RequestParam Long participantId
     ) {
-        List<MessageItemResult> result = queryService.getMessagesBetweenUsers(
-                userId,
-                participantId
-        );
+        var result = queryService.getMessagesBetweenUsers(userId, participantId);
         return ResponseEntity.ok(ApiResponseFactory.success("쪽지 내용들을 조회하였습니다.", result));
     }
 

--- a/src/main/java/com/example/bak/privatemessage/presentation/MessageController.java
+++ b/src/main/java/com/example/bak/privatemessage/presentation/MessageController.java
@@ -1,0 +1,84 @@
+package com.example.bak.privatemessage.presentation;
+
+import com.example.bak.global.common.response.ApiResponse;
+import com.example.bak.global.common.response.ApiResponseFactory;
+import com.example.bak.privatemessage.application.command.MessageCommandService;
+import com.example.bak.privatemessage.application.query.MessageQueryService;
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/private-messages")
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageCommandService commandService;
+    private final MessageQueryService queryService;
+
+    @PostMapping()
+    public ResponseEntity<ApiResponse> sendMessage(
+            @RequestBody MessageRequest request
+    ) {
+        commandService.sendMessage(
+                request.senderId(),
+                request.receiverId(),
+                request.content()
+        );
+
+        return ResponseEntity.ok(
+                ApiResponseFactory.successVoid("쪽지를 성공적으로 전송했습니다.")
+        );
+    }
+
+    @GetMapping("/participants")
+    public ResponseEntity<ApiResponse> getParticipants(@RequestParam Long userId) {
+        List<MessagePartnerResult> result = queryService.getPartnersByUserId(userId);
+        return ResponseEntity.ok(ApiResponseFactory.success("쪽지 대화 상대 목록을 조회하였습니다.", result));
+    }
+
+    @GetMapping()
+    public ResponseEntity<ApiResponse> getMessagesBetweenUsers(
+            @RequestParam Long userId,
+            @RequestParam Long participantId
+    ) {
+        List<MessageItemResult> result = queryService.getMessagesBetweenUsers(
+                userId,
+                participantId
+        );
+        return ResponseEntity.ok(ApiResponseFactory.success("쪽지 내용들을 조회하였습니다.", result));
+    }
+
+    @PatchMapping("/read")
+    public ResponseEntity<ApiResponse> markAsRead(
+            @RequestParam Long userId,
+            @RequestParam Long participantId
+    ) {
+        commandService.markAsRead(userId, participantId);
+        return ResponseEntity.ok(
+                ApiResponseFactory.successVoid("읽음 처리되었습니다.")
+        );
+    }
+
+    @DeleteMapping("/{messageId}")
+    public ResponseEntity<ApiResponse> deleteMessage(
+            @RequestParam Long userId,
+            @PathVariable Long messageId
+    ) {
+        commandService.deleteMessage(userId, messageId);
+        return ResponseEntity.ok(
+                ApiResponseFactory.successVoid("쪽지를 삭제했습니다.")
+        );
+    }
+}

--- a/src/main/java/com/example/bak/privatemessage/presentation/MessageController.java
+++ b/src/main/java/com/example/bak/privatemessage/presentation/MessageController.java
@@ -34,15 +34,16 @@ public class MessageController {
                 request.content()
         );
 
-        return ResponseEntity.ok(
-                ApiResponseFactory.successVoid("쪽지를 성공적으로 전송했습니다.")
-        );
+        ApiResponse response = ApiResponseFactory.successVoid("쪽지를 성공적으로 전송했습니다.");
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/participants")
     public ResponseEntity<ApiResponse> getParticipants(@RequestParam Long userId) {
         var result = queryService.getMessageCorrespondentsByUserId(userId);
-        return ResponseEntity.ok(ApiResponseFactory.success("쪽지 대화 상대 목록을 조회하였습니다.", result));
+
+        ApiResponse response = ApiResponseFactory.success("쪽지 대화 상대 목록을 조회하였습니다.", result);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping()
@@ -51,7 +52,9 @@ public class MessageController {
             @RequestParam Long participantId
     ) {
         var result = queryService.getMessagesBetweenUsers(userId, participantId);
-        return ResponseEntity.ok(ApiResponseFactory.success("쪽지 내용들을 조회하였습니다.", result));
+
+        ApiResponse response = ApiResponseFactory.success("쪽지 내용들을 조회하였습니다.", result);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/read")
@@ -60,9 +63,9 @@ public class MessageController {
             @RequestParam Long participantId
     ) {
         commandService.markAsRead(userId, participantId);
-        return ResponseEntity.ok(
-                ApiResponseFactory.successVoid("읽음 처리되었습니다.")
-        );
+
+        ApiResponse response = ApiResponseFactory.successVoid("읽음 처리되었습니다.");
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{messageId}")
@@ -71,8 +74,8 @@ public class MessageController {
             @PathVariable Long messageId
     ) {
         commandService.deleteMessage(userId, messageId);
-        return ResponseEntity.ok(
-                ApiResponseFactory.successVoid("쪽지를 삭제했습니다.")
-        );
+
+        ApiResponse response = ApiResponseFactory.successVoid("쪽지를 삭제했습니다.");
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/bak/privatemessage/presentation/MessageRequest.java
+++ b/src/main/java/com/example/bak/privatemessage/presentation/MessageRequest.java
@@ -1,0 +1,9 @@
+package com.example.bak.privatemessage.presentation;
+
+public record MessageRequest(
+        Long senderId,
+        Long receiverId,
+        String content
+) {
+
+}

--- a/src/test/java/com/example/bak/global/AbstractMySqlContainerTest.java
+++ b/src/test/java/com/example/bak/global/AbstractMySqlContainerTest.java
@@ -1,0 +1,31 @@
+package com.example.bak.global;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JdbcRepositoryTestConfig.class)
+public abstract class AbstractMySqlContainerTest {
+
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.36")
+                    .withDatabaseName("test")
+                    .withUsername("test")
+                    .withPassword("test")
+                    .withInitScripts("sql/schema.sql");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+}

--- a/src/test/java/com/example/bak/global/JdbcRepositoryTestConfig.java
+++ b/src/test/java/com/example/bak/global/JdbcRepositoryTestConfig.java
@@ -1,0 +1,16 @@
+package com.example.bak.global;
+
+import com.example.bak.privatemessage.infra.query.jdbc.MessageJdbcRepository;
+import com.example.bak.privatemessage.infra.query.jdbc.MessageJdbcRepositoryImpl;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@TestConfiguration
+public class JdbcRepositoryTestConfig {
+
+    @Bean
+    public MessageJdbcRepository messageJdbcRepository(NamedParameterJdbcTemplate jdbc) {
+        return new MessageJdbcRepositoryImpl(jdbc);
+    }
+}

--- a/src/test/java/com/example/bak/privatemessage/application/command/MessageCommandServiceUnitTest.java
+++ b/src/test/java/com/example/bak/privatemessage/application/command/MessageCommandServiceUnitTest.java
@@ -1,0 +1,112 @@
+package com.example.bak.privatemessage.application.command;
+
+import static com.example.bak.global.utils.AssertionsErrorCode.assertBusiness;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.example.bak.global.exception.ErrorCode;
+import com.example.bak.privatemessage.domain.Message;
+import com.example.bak.privatemessage.infra.command.support.MessageCommandPortStub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MessageCommandService 단위 테스트")
+class MessageCommandServiceUnitTest {
+
+    private MessageCommandService service;
+    private MessageCommandPortStub port;
+
+    @BeforeEach
+    void setUp() {
+        port = new MessageCommandPortStub();
+        service = new MessageCommandService(port);
+    }
+
+    private Message setupMessage(Long senderId, Long receiverId, String content) {
+        Message message = Message.create(senderId, receiverId, content);
+        return port.save(message);
+    }
+
+    @Nested
+    @DisplayName("sendMessage")
+    class SendMessageTest {
+
+        @Test
+        @DisplayName("쪽지 전송에 성공한다")
+        void sendMessage_success() {
+            service.sendMessage(1L, 2L, "hello");
+
+            Message saved = port.findAll().getFirst();
+            assertThat(saved.getMessageParticipants().getSenderId()).isEqualTo(1L);
+            assertThat(saved.getMessageParticipants().getReceiverId()).isEqualTo(2L);
+            assertThat(saved.getMessageState().getReadAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsRead")
+    class MarkAsReadTest {
+
+        @Test
+        @DisplayName("특정 사용자 간 메시지를 모두 읽음 처리한다")
+        void markAsRead_success() {
+            Message m1 = setupMessage(1L, 2L, "a");
+            Message m2 = setupMessage(1L, 2L, "b");
+            Message m3 = setupMessage(2L, 1L, "c");
+
+            service.markAsRead(1L, 2L);
+
+            assertThat(m1.getMessageState().getReadAt()).isNotNull();
+            assertThat(m2.getMessageState().getReadAt()).isNotNull();
+            assertThat(m3.getMessageState().getReadAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMessage")
+    class DeleteMessageTest {
+
+        @Test
+        @DisplayName("보낸 사람이 메시지를 삭제할 수 있다")
+        void deleteMessage_sender_success() {
+            Message msg = setupMessage(1L, 2L, "hi");
+
+            service.deleteMessage(1L, msg.getId());
+
+            assertThat(msg.getMessageState().getDeletedAtBySender()).isNotNull();
+            assertThat(msg.getMessageState().getDeletedAtByReceiver()).isNull();
+        }
+
+        @Test
+        @DisplayName("받는 사람이 메시지를 삭제할 수 있다")
+        void deleteMessage_receiver_success() {
+            Message msg = setupMessage(1L, 2L, "hi");
+
+            service.deleteMessage(2L, msg.getId());
+
+            assertThat(msg.getMessageState().getDeletedAtBySender()).isNull();
+            assertThat(msg.getMessageState().getDeletedAtByReceiver()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 메시지는 예외를 던진다")
+        void deleteMessage_notFound() {
+            assertBusiness(
+                    () -> service.deleteMessage(1L, 999L),
+                    ErrorCode.MESSAGE_NOT_FOUND
+            );
+        }
+
+        @Test
+        @DisplayName("메시지의 sender와 receiver 모두가 아닌 사용자는 삭제할 수 없다")
+        void deleteMessage_unauthorized() {
+            Message msg = setupMessage(1L, 2L, "hi");
+
+            assertBusiness(
+                    () -> service.deleteMessage(999L, msg.getId()),
+                    ErrorCode.UNAUTHORIZED_ACTION
+            );
+        }
+    }
+}

--- a/src/test/java/com/example/bak/privatemessage/infra/command/MessageJpaRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/bak/privatemessage/infra/command/MessageJpaRepositoryIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.example.bak.privatemessage.infra.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.bak.global.AbstractMySqlContainerTest;
+import com.example.bak.privatemessage.domain.Message;
+import com.example.bak.privatemessage.domain.MessageParticipants;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@Slf4j
+@DataJpaTest
+@Sql(scripts = "/sql/message/data.sql")
+@DisplayName("MessageJpaRepository 통합 테스트")
+class MessageJpaRepositoryIntegrationTest extends AbstractMySqlContainerTest {
+
+    @Autowired
+    MessageJpaRepository messageJpaRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("특정 발신·수신자 조합의 읽지 않은 메시지를 모두 읽음 처리한다")
+    void test_mark_messages_as_read() {
+        // given
+        MessageParticipants participants = MessageParticipants.of(1L, 2L);
+
+        List<Message> beforeMessages = findMessages(participants);
+        assertThat(beforeMessages)
+                .isNotEmpty()
+                .allMatch(msg -> msg.getMessageState().getReadAt() == null);
+
+        // when
+        int updatedCount = messageJpaRepository.markAsReadByParticipants(
+                participants.getSenderId(),
+                participants.getReceiverId()
+        );
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(updatedCount).isEqualTo(beforeMessages.size());
+
+        List<Message> afterMessages = findMessages(participants);
+        assertThat(afterMessages)
+                .isNotEmpty()
+                .allMatch(msg -> msg.getMessageState().getReadAt() != null);
+    }
+
+    private List<Message> findMessages(MessageParticipants participants) {
+        return em.createQuery("""
+                        SELECT m FROM private_messages m
+                         WHERE m.messageParticipants.senderId = :senderId
+                           AND m.messageParticipants.receiverId = :receiverId
+                        """, Message.class)
+                .setParameter("senderId", participants.getSenderId())
+                .setParameter("receiverId", participants.getReceiverId())
+                .getResultList();
+    }
+}

--- a/src/test/java/com/example/bak/privatemessage/infra/command/support/MessageCommandPortStub.java
+++ b/src/test/java/com/example/bak/privatemessage/infra/command/support/MessageCommandPortStub.java
@@ -1,0 +1,41 @@
+package com.example.bak.privatemessage.infra.command.support;
+
+import com.example.bak.global.support.AbstractStubRepository;
+import com.example.bak.privatemessage.application.command.port.MessageCommandPort;
+import com.example.bak.privatemessage.domain.Message;
+import com.example.bak.privatemessage.domain.MessageParticipants;
+import java.util.Objects;
+
+public class MessageCommandPortStub
+        extends AbstractStubRepository<Long, Message>
+        implements MessageCommandPort {
+
+    @Override
+    protected Long getId(Message message) {
+        return message.getId();
+    }
+
+    @Override
+    protected boolean isSame(Long left, Long right) {
+        return Objects.equals(left, right);
+    }
+
+    @Override
+    public void markAsRead(MessageParticipants participants) {
+        Long senderId = participants.getSenderId();
+        Long receiverId = participants.getReceiverId();
+
+        for (Message message : store) {
+            boolean isTarget =
+                    message.getMessageParticipants().getSenderId().equals(senderId) &&
+                            message.getMessageParticipants().getReceiverId().equals(receiverId);
+
+            boolean unread =
+                    message.getMessageState().getReadAt() == null;
+
+            if (isTarget && unread) {
+                message.getMessageState().markAsRead();
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/bak/privatemessage/infra/query/MessageJdbcRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/bak/privatemessage/infra/query/MessageJdbcRepositoryIntegrationTest.java
@@ -3,8 +3,8 @@ package com.example.bak.privatemessage.infra.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.bak.global.AbstractMySqlContainerTest;
+import com.example.bak.privatemessage.application.query.dto.MessageCorrespondentResult;
 import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
-import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
 import com.example.bak.privatemessage.infra.query.jdbc.MessageJdbcRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -24,18 +24,18 @@ public class MessageJdbcRepositoryIntegrationTest extends AbstractMySqlContainer
     private MessageJdbcRepository messageJdbcRepository;
 
     @Nested
-    @DisplayName("findPartnersByUserId 메소드 쿼리 테스트")
-    class FindPartnersByUserIdTest {
+    @DisplayName("findCorrespondentsByUserId 메소드 쿼리 테스트")
+    class FindCorrespondentsByUserIdTest {
 
         @Test
         @DisplayName("성공 케이스")
-        public void test_find_partners_by_userid_success() {
-            var result = messageJdbcRepository.findPartnersByUserId(1L);
+        public void test_find_correspondents_by_userid_success() {
+            var result = messageJdbcRepository.findCorrespondentsByUserId(1L);
 
             assertThat(result).isNotEmpty();
             assertThat(result).containsExactly(
-                    new MessagePartnerResult(2L, "u2", true),
-                    new MessagePartnerResult(3L, "u3", false)
+                    new MessageCorrespondentResult(2L, "u2", true),
+                    new MessageCorrespondentResult(3L, "u3", false)
             );
         }
     }

--- a/src/test/java/com/example/bak/privatemessage/infra/query/MessageJdbcRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/bak/privatemessage/infra/query/MessageJdbcRepositoryIntegrationTest.java
@@ -1,0 +1,61 @@
+package com.example.bak.privatemessage.infra.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.bak.global.AbstractMySqlContainerTest;
+import com.example.bak.privatemessage.application.query.dto.MessageItemResult;
+import com.example.bak.privatemessage.application.query.dto.MessagePartnerResult;
+import com.example.bak.privatemessage.infra.query.jdbc.MessageJdbcRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@Slf4j
+@JdbcTest
+@DisplayName("MessageJdbcRepository 통합 테스트")
+@Sql(scripts = "/sql/message/data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+public class MessageJdbcRepositoryIntegrationTest extends AbstractMySqlContainerTest {
+
+    @Autowired
+    private MessageJdbcRepository messageJdbcRepository;
+
+    @Nested
+    @DisplayName("findPartnersByUserId 메소드 쿼리 테스트")
+    class FindPartnersByUserIdTest {
+
+        @Test
+        @DisplayName("성공 케이스")
+        public void test_find_partners_by_userid_success() {
+            var result = messageJdbcRepository.findPartnersByUserId(1L);
+
+            assertThat(result).isNotEmpty();
+            assertThat(result).containsExactly(
+                    new MessagePartnerResult(2L, "u2", true),
+                    new MessagePartnerResult(3L, "u3", false)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("findMessagesBetweenUsers 메소드 쿼리 테스트")
+    class FindMessagesBetweenUsers {
+
+        @Test
+        @DisplayName("성공 케이스")
+        public void test_find_messages_between_users_success() {
+            var result = messageJdbcRepository.findMessagesBetweenUsers(1L, 2L);
+
+            assertThat(result).isNotEmpty();
+            assertThat(result).containsExactly(
+                    new MessageItemResult(3L, 2L, 1L, "message3", null),
+                    new MessageItemResult(2L, 1L, 2L, "message2", null),
+                    new MessageItemResult(1L, 1L, 2L, "message1", null)
+            );
+        }
+    }
+}
+

--- a/src/test/resources/sql/message/data.sql
+++ b/src/test/resources/sql/message/data.sql
@@ -1,0 +1,27 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE private_messages;
+TRUNCATE TABLE profiles;
+TRUNCATE TABLE users;
+
+SET FOREIGN_KEY_CHECKS = 1;
+-- Users
+INSERT INTO users (id, email, password)
+VALUES (1, 'u1@test.com', 'pw'),
+       (2, 'u2@test.com', 'pw'),
+       (3, 'u3@test.com', 'pw');
+
+-- Profiles (JOIN 의 필수 조건: p.user_id = partner_id)
+INSERT INTO profiles (id, name, nickname, user_id)
+VALUES (1, 'User One', 'u1', 1),
+       (2, 'User Two', 'u2', 2),
+       (3, 'User Three', 'u3', 3);
+
+-- Private messages
+-- 1) user 1 → user 2 메시지 (삭제되지 않음 → partner 관계 생성)
+INSERT INTO private_messages (sender_id, receiver_id, content, read_at, deleted_at_by_sender,
+                              deleted_at_by_receiver)
+VALUES (1, 2, 'message1', NULL, NULL, NULL)
+     , (1, 2, 'message2', NULL, NULL, NULL)
+     , (2, 1, 'message3', NULL, NULL, NULL)
+     , (1, 3, 'message4', NULL, NULL, NULL);;

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -1,0 +1,76 @@
+
+-- Drop tables if they exist to start with a clean slate
+DROP TABLE IF EXISTS feed_comments;
+DROP TABLE IF EXISTS feeds;
+DROP TABLE IF EXISTS communities;
+DROP TABLE IF EXISTS profiles;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS companies;
+DROP TABLE IF EXISTS private_messages;
+
+-- Table for Companies
+CREATE TABLE companies (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    career_link VARCHAR(255) NOT NULL,
+    logo_url VARCHAR(255) NOT NULL,
+    description VARCHAR(255) NOT NULL
+);
+
+-- Table for Users
+CREATE TABLE users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+);
+
+-- Table for Profiles
+CREATE TABLE profiles (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    nickname VARCHAR(255) NOT NULL,
+    user_id BIGINT,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Table for Communities
+CREATE TABLE communities (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    job_group VARCHAR(255) NOT NULL,
+    company_id BIGINT,
+    FOREIGN KEY (company_id) REFERENCES companies(id)
+);
+
+-- Table for Feeds
+CREATE TABLE feeds (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    community_id BIGINT,
+    author_id BIGINT,
+    FOREIGN KEY (community_id) REFERENCES communities(id),
+    FOREIGN KEY (author_id) REFERENCES users(id)
+);
+
+-- Table for Feed Comments
+CREATE TABLE feed_comments (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    comment TEXT NOT NULL,
+    author_id BIGINT,
+    feed_id BIGINT,
+    FOREIGN KEY (author_id) REFERENCES users(id),
+    FOREIGN KEY (feed_id) REFERENCES feeds(id)
+);
+
+-- Table for Private Messages
+CREATE TABLE private_messages (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    sender_id BIGINT NOT NULL,
+    receiver_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    read_at DATETIME,
+    deleted_at_by_sender DATETIME,
+    deleted_at_by_receiver DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
> [!WARNING]
> **이슈와 프로젝트(Project) 연결 시 반드시 주의하세요.**
> 이는 업무 효율도를 위해서 사용하는 것이지 때문에 협조 부탁드립니다. 추가로, 완료 된 PR 이라면 리뷰어를 직접적으로 연결해주세요 :)

## 📌 연결된 이슈
- resolve #20 

## 📖 주요 변경 사항
- PrivateMessage 도메인 내에 CQRS 패턴 기반 첫 도입
  - 복잡한 조회에 대해서 다루는 것은 native query 가 훨씬 효율적입니다. Aggregate 의 생명 주기를 활용하 수도 없고, 오히려 EntityManager 를 활용하는 것이 오버헤드가 된다고 판단 했습니다.
  - Dirty checking 기능이나 연관관계 로딩에 대한 부분을 조회 부분에서 사용하지 않기 때문에 적합하다고 판단했습니다.
  - Application Level 에서의 CQRS 를 나누는 형태를 기반으로 했고, 규모가 커짐에 따라서 분리하기 적합한 구조에 대해서 고민했습니다.

- Port&Adapter 패턴을 활용하여, Application Layer 에서 Infra 를 직접적으로 참조하지 않도록 했습니다.
- Query 에 대한 부분은 민감한 사항으로 판단해서 Jdbc 통합 테스트를 MySQLContainer 기반으로 진행하였습니다.  따로 기저 케이스는 보이지 않아서, Best 케이스에 대해서만 처리했습니다.
- `ReadOnlyRepository` 라는 인터페이스가 추가되었고, 이를 통해서 Jpa를 사용하되, 생성과 같은 로직을 사용하지 않는 방향으로 Query 레벨에서도 쓸 수 있도록 처리하였습니다. (하지만, 추후에 2차 검증이 필요해 보입니다.)

<img width="1460" height="906" alt="image" src="https://github.com/user-attachments/assets/feb71aa3-e0bb-4649-a4bd-7e72a1cf009c" />

Test 를 작성하면서 실제 로직에서 잘못된 부분 3군데를 미리 캐치할 수 있어서 좋았습니다! 리뷰 꼼꼼하게 해주세요

## 😎 질문
> 작업하면서 궁금했던 점이나, 공유하고 싶은 내용이 있다면 작성해주세요
사실 이 작업을 진행하면서, 고민이 들었던 부분이 많았습니다. 
- Query 를 JDBC 를 통해서 하면서 이 쿼리를 따로 분리해서 관리하는게 가시성이 좋고, 로직과 실제 query 관점을 분리해서 바라볼 수 있을 것 같은데 어떤 방식이 가장 가볍고 빠르게 할 수 있을지 현재 고려중에 있습니다.

- QueryDSL 은 동적쿼리 용도, 복잡한 쿼리는 JDBC 로 처리하는 걸로 하는게 괜찮아보이는데, 다들 어떻게 생각하시나요?

- 그리고, 이 프로젝트가 배포가 되어가면 실제 flyway 를 달고, 테스트용 flyway 버전 관리, 배포용 버전 관리를 진행하면 좋을 것 같다는 생각을 했습니다.

